### PR TITLE
Add support for tag OBJE as a child of a SOUR tag

### DIFF
--- a/src/org/gedcom4j/parser/GedcomParser.java
+++ b/src/org/gedcom4j/parser/GedcomParser.java
@@ -431,6 +431,8 @@ public class GedcomParser {
                 cws.certainty = new StringWithCustomTags(ch);
             } else if ("NOTE".equals(ch.tag)) {
                 loadNote(ch, cws.notes);
+            } else if ("OBJE".equals(ch.tag)) {
+                loadMultimediaLink(ch, cws.multimedia);
             } else {
                 unknownTag(ch, citation);
             }

--- a/test/org/gedcom4j/parser/GedcomParserTest.java
+++ b/test/org/gedcom4j/parser/GedcomParserTest.java
@@ -28,8 +28,15 @@ import java.io.InputStream;
 
 import junit.framework.TestCase;
 
+import org.gedcom4j.model.CitationWithSource;
+import org.gedcom4j.model.CitationWithoutSource;
 import org.gedcom4j.model.Family;
+import org.gedcom4j.model.FileReference;
 import org.gedcom4j.model.Gedcom;
+import org.gedcom4j.model.Individual;
+import org.gedcom4j.model.Multimedia;
+import org.gedcom4j.model.Note;
+import org.gedcom4j.model.PersonalName;
 import org.gedcom4j.model.Source;
 import org.gedcom4j.model.Submitter;
 import org.junit.Test;
@@ -167,6 +174,36 @@ public class GedcomParserTest extends TestCase {
     }
 
     /**
+     * Test loading a file.
+     * 
+     * @throws IOException
+     *             if the file can't be read
+     * @throws GedcomParserException
+     *             if there's a problem parsing the data
+     */
+    public void testLoadTGC55C() throws IOException, GedcomParserException {
+        GedcomParser gp = new GedcomParser();
+        gp.verbose = true;
+        gp.load("sample/TGC55C.ged");
+        checkTGC55C(gp);
+    }
+
+    /**
+     * Test loading a file.
+     * 
+     * @throws IOException
+     *             if the file can't be read
+     * @throws GedcomParserException
+     *             if there's a problem parsing the data
+     */
+    public void testLoadTGC55CLF() throws IOException, GedcomParserException {
+        GedcomParser gp = new GedcomParser();
+        gp.verbose = true;
+        gp.load("sample/TGC55CLF.ged");
+        checkTGC55C(gp);
+    }
+
+    /**
      * Test for loading file from stream.
      * 
      * @throws IOException
@@ -203,5 +240,172 @@ public class GedcomParserTest extends TestCase {
         assertEquals(2, g.sources.size());
         assertEquals(1, g.multimedia.size());
         assertEquals(15, g.individuals.size());
+    }
+
+    /**
+     * The same sample file is used several times, this helper method ensures
+     * consistent assertions for all tests using the same file
+     * 
+     * @param gp
+     *            the {@link GedcomParser}
+     */
+    private void checkTGC55C(GedcomParser gp) {
+        Individual indi;
+        PersonalName name;
+        Note note;
+        Multimedia multimedia;
+        FileReference fileReference;
+        CitationWithSource citWithSource;
+        CitationWithoutSource citWithoutSource;
+        Source source;
+
+        assertTrue(gp.errors.isEmpty());
+        assertTrue(gp.warnings.isEmpty());
+        Gedcom g = gp.gedcom;
+        assertNotNull(g.header);
+        assertEquals(3, g.submitters.size());
+        Submitter submitter = g.submitters.get("@SUBMITTER@");
+        assertNotNull(submitter);
+        assertEquals("John A. Nairn", submitter.name.value);
+
+        assertEquals(7, g.families.size());
+        assertEquals(2, g.sources.size());
+        assertEquals(1, g.multimedia.size());
+        assertEquals(15, g.individuals.size());
+
+        // ===============================================================
+        // Individual @PERSON1@
+        // ===============================================================
+        indi = g.individuals.get("@PERSON1@");
+
+        assertEquals("@PERSON1@", indi.xref);
+
+        assertEquals(3, indi.citations.size());
+        assertEquals(2, indi.names.size());
+        assertEquals(2, indi.notes.size());
+
+        // Name 0
+        name = indi.names.get(0);
+        assertEquals("Joseph Tag /Torture/", name.basic);
+        assertEquals("Torture, Joseph \"Joe\"", name.toString());
+
+        assertEquals(1, name.citations.size());
+        assertEquals(1, name.notes.size());
+
+        // Name 0 - Citation 0
+        assertTrue(name.citations.get(0) instanceof CitationWithSource);
+        citWithSource = (CitationWithSource)name.citations.get(0);
+        source = citWithSource.source;
+
+        assertEquals("@SOURCE1@", source.xref);
+        assertEquals("42", citWithSource.whereInSource.toString());
+
+        assertEquals(0, citWithSource.multimedia.size());
+        assertEquals(0, citWithSource.notes.size());
+
+        // Name 0 - Note 0
+        note = name.notes.get(0);
+        assertEquals(5, note.lines.size());
+        assertEquals("These are notes about the first NAME structure in this record. These notes are embedded in the INDIVIDUAL record itself.", note.lines.get(0));
+
+        // Name 1
+        name = indi.names.get(1);
+        assertEquals("William John /Smith/", name.basic);
+        assertEquals("William John /Smith/", name.toString());
+
+        assertEquals(1, name.citations.size());
+        assertEquals(1, name.notes.size());
+
+        // Name 1 - Citation 0
+        assertTrue(name.citations.get(0) instanceof CitationWithSource);
+        citWithSource = (CitationWithSource)name.citations.get(0);
+        source = citWithSource.source;
+
+        assertEquals("@SOURCE1@", source.xref);
+        assertEquals("55", citWithSource.whereInSource.toString());
+
+        assertEquals(1, citWithSource.multimedia.size());
+        assertEquals(1, citWithSource.notes.size());
+
+        // Name 1 - Multimedia 0
+        multimedia = citWithSource.multimedia.get(0);
+        assertEquals(0, multimedia.citations.size());
+        assertEquals(1, multimedia.fileReferences.size());
+        assertEquals(1, multimedia.notes.size());
+
+        // Name 1 - Multimedia 0 - FileReference 0
+        fileReference = multimedia.fileReferences.get(0);
+        assertEquals("jpeg", fileReference.format.toString());
+        assertEquals(null, fileReference.mediaType);
+        assertEquals("ImgFile.JPG", fileReference.referenceToFile.toString());
+        assertEquals(null, fileReference.title);
+
+        // Name 1 - Multimedia 0 - Note 0
+        note = multimedia.notes.get(0);
+        assertEquals(1, note.lines.size());
+        assertEquals("These are some notes of this multimedia link in the NAME structure.", note.lines.get(0));
+
+        // Name 1 - Citation 0 - Note 0
+        note = citWithSource.notes.get(0);
+        assertEquals(3, note.lines.size());
+        assertEquals("This source citation has all fields possible in a source citation to a separate SOURCE record. Besides the link to the SOURCE record there are possible fields about this citation (e.g., PAGE, TEXT, etc.)", note.lines.get(0));
+
+        // Name 1 - Note 0
+        note = name.notes.get(0);
+        assertEquals(3, note.lines.size());
+        assertEquals("This is a second personal NAME structure in a single INDIVIDUAL record which is allowed in GEDCOM. This second NAME structure has all possible fields for a NAME structure.", note.lines.get(0));
+
+        // Note 0
+        note = indi.notes.get(0);
+        assertEquals(40, note.lines.size());
+        assertEquals("Comments on \"Joseph Tag Torture\" INDIVIDUAL Record.", note.lines.get(0));
+
+        // Note 1
+        note = indi.notes.get(1);
+        assertEquals(3, note.lines.size());
+        assertEquals("This is a second set of notes for this single individual record. It is embedded in the INDIVIDUAL record instead of being in a separate NOTE record.", note.lines.get(0));
+
+        // Citation 0
+        assertTrue(indi.citations.get(0) instanceof CitationWithSource);
+        citWithSource = (CitationWithSource)indi.citations.get(0);
+        source = citWithSource.source;
+
+        assertEquals("@SOURCE1@", source.xref);
+        assertEquals("42", citWithSource.whereInSource.toString());
+
+        assertEquals(0, citWithSource.multimedia.size());
+        assertEquals(1, citWithSource.notes.size());
+
+        // Citation 0 - Note 0
+        note = citWithSource.notes.get(0);
+        assertEquals(1, note.lines.size());
+        assertEquals("A source note.", note.lines.get(0));
+
+        // Citation 1
+        assertTrue(indi.citations.get(1) instanceof CitationWithSource);
+        citWithSource = (CitationWithSource)indi.citations.get(1);
+        source = citWithSource.source;
+
+        assertEquals("@SR2@", source.xref);
+        assertEquals(null, citWithSource.whereInSource);
+
+        assertEquals(0, citWithSource.multimedia.size());
+        assertEquals(1, citWithSource.notes.size());
+
+        // Citation 1 - Note 0
+        note = citWithSource.notes.get(0);
+        assertEquals(1, note.lines.size());
+        assertEquals("This is a second source citation in this record.", note.lines.get(0));
+
+        // Citation 2
+        assertTrue(indi.citations.get(2) instanceof CitationWithoutSource);
+        citWithoutSource = (CitationWithoutSource)indi.citations.get(2);
+
+        assertEquals(1, citWithoutSource.notes.size());
+
+        // Citation 2 - Note 0
+        note = citWithoutSource.notes.get(0);
+        assertEquals(1, note.lines.size());
+        assertEquals("How does software handle embedded SOURCE records on import? Such source citations are common in old GEDCOM files. More modern GEDCOM files should use source citations to SOURCE records.", note.lines.get(0));
     }
 }


### PR DESCRIPTION
This PR adds support for tag OBJE as a child of a SOUR tag. The already existing test file TGC55C contains this type of structure and a unit test as been added to show the issue and verify that is has been solved.
