### PR TITLE
Removing OSSRH in order to test Jenkins fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- OSSRH parent from Sonatype -->
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
-
     <!-- Derived from the src files and gedcom4j.properties -->
     <groupId>org.gedcom4j</groupId>
     <artifactId>gedcom4j</artifactId>


### PR DESCRIPTION
Removing OSSRH parent in order to test if removal fixes Jenkins build.