### PR TITLE
Increases heap memory for FindBugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,9 @@
                 <configuration>
                     <!-- Make sure that Findbugs writes an XML file -->
                     <xmlOutput>true</xmlOutput>
+                    <!-- FindBugs defaults to 768M of heap space, but the Maven plugin
+                        defaults to only 512M -->
+                    <maxHeap>768</maxHeap>
                 </configuration>
             </plugin>
             <!-- Execute the Cobertura plugin during the test phase -->


### PR DESCRIPTION
This should fix the issues on the Jenkins. Tested locally and successful.

Information about FindBugs memory here: [FindBugs FAQ](http://findbugs.sourceforge.net/FAQ.html)
Information about FindBugs Maven plugin here: [FindBugs Maven Plugin Goal](https://gleclaire.github.io/findbugs-maven-plugin/findbugs-mojo.html)