### PR TITLE
moving PMD, Checkstyle, FindBugs, and Cobertura tasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,83 +73,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Execute the PMD plugin during the test phase -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.0</version>
-                <executions>
-                    <execution>
-                        <id>pmd</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>pmd</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <!-- PMD defaults to 1.8, need to specify that we're using 1.6 -->
-                    <targetJdk>1.6</targetJdk>
-                    <!-- Adding the PMD configuration file in root directory -->
-                    <rulesets>
-                        <ruleset>${project.basedir}/pmd-config.xml</ruleset>
-                    </rulesets>
-                </configuration>
-            </plugin>
-            <!-- Execute the FindBugs plugin during the test phase -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>2.5.2</version>
-                <executions>
-                    <execution>
-                        <id>findbugs</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>findbugs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <!-- Make sure that Findbugs writes an XML file -->
-                    <xmlOutput>true</xmlOutput>
-                    <maxHeap>768</maxHeap>
-                </configuration>
-            </plugin>
-            <!-- Execute the Cobertura plugin during the test phase -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.5.2</version>
-                <executions>
-                    <execution>
-                        <id>cobertura</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>cobertura</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- Execute the Checkstyle plugin during the test phase -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.9.1</version>
-                <executions>
-                    <execution>
-                        <id>checkstyle</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>checkstyle</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <configLocation>${project.basedir}/checkstyle-config.xml</configLocation>
-                </configuration>
-            </plugin>
             <!-- Sign artifacts with GnuPG: see https://maven.apache.org/plugins/maven-gpg-plugin/usage.html -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -170,8 +93,54 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+            </plugin>
         </plugins>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <configLocation>${project.basedir}/checkstyle-config.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <!-- Make sure that Findbugs writes an XML file -->
+                    <xmlOutput>true</xmlOutput>
+                    <maxHeap>768</maxHeap>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <!-- PMD defaults to 1.8, need to specify that we're using 1.6 -->
+                    <targetJdk>1.6</targetJdk>
+                    <!-- Adding the PMD configuration file in root directory -->
+                    <rulesets>
+                        <ruleset>${project.basedir}/pmd-config.xml</ruleset>
+                    </rulesets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
Moved tasks to reporting in order to speed up local builds. Requires specifying the ```pmd:pmd```, ```checkstyle:checkstyle```, ```findbugs:findbugs```, and ```cobertura:cobertura``` tasks on the Jenkins.