### PR TITLE
Multiple code improvements - squid:S1155, squid:S1066, squid:S1213, squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/org/gedcom4j/comparators/IndividualByLastNameFirstNameComparator.java
+++ b/src/main/java/org/gedcom4j/comparators/IndividualByLastNameFirstNameComparator.java
@@ -56,10 +56,10 @@ public class IndividualByLastNameFirstNameComparator implements Serializable, Co
         String s2 = "-unknown-";
         PersonalName n1 = null;
         PersonalName n2 = null;
-        if (i1.names.size() > 0) {
+        if (!i1.names.isEmpty()) {
             n1 = i1.names.get(0);
         }
-        if (i2.names.size() > 0) {
+        if (!i2.names.isEmpty()) {
             n2 = i2.names.get(0);
         }
 

--- a/src/main/java/org/gedcom4j/io/AnselHandler.java
+++ b/src/main/java/org/gedcom4j/io/AnselHandler.java
@@ -282,7 +282,7 @@ class AnselHandler {
      * @return true if ANSEL string ends in a combining diacritical
      */
     private boolean endsWithDiacritical(String s) {
-        return (s.charAt(s.length() - 1) >= ANSEL_DIACRITICS_BEGIN_AT);
+        return s.charAt(s.length() - 1) >= ANSEL_DIACRITICS_BEGIN_AT;
     }
 
     /**
@@ -2226,11 +2226,9 @@ class AnselHandler {
             }
 
         }
-        if (baseChar == 'F') {
-            if (modifier1 == '\u00E7' /* DOT ABOVE */) {
-                /* LATIN CAPITAL LETTER F WITH DOT ABOVE */
-                return '\u1E1E';
-            }
+        if (baseChar == 'F' && modifier1 == '\u00E7' /* DOT ABOVE */) {
+            /* LATIN CAPITAL LETTER F WITH DOT ABOVE */
+            return '\u1E1E';
 
         }
         if (baseChar == 'G') {
@@ -2373,11 +2371,9 @@ class AnselHandler {
             }
 
         }
-        if (baseChar == 'J') {
-            if (modifier1 == '\u00E3' /* CIRCUMFLEX */) {
-                /* LATIN CAPITAL LETTER J WITH CIRCUMFLEX */
-                return '\u0134';
-            }
+        if (baseChar == 'J' && modifier1 == '\u00E3' /* CIRCUMFLEX */) {
+            /* LATIN CAPITAL LETTER J WITH CIRCUMFLEX */
+            return '\u0134';
 
         }
         if (baseChar == 'K') {
@@ -3236,11 +3232,9 @@ class AnselHandler {
             }
 
         }
-        if (baseChar == 'f') {
-            if (modifier1 == '\u00E7' /* DOT ABOVE */) {
-                /* LATIN SMALL LETTER F WITH DOT ABOVE */
-                return '\u1E1F';
-            }
+        if (baseChar == 'f' && modifier1 == '\u00E7' /* DOT ABOVE */) {
+            /* LATIN SMALL LETTER F WITH DOT ABOVE */
+            return '\u1E1F';
 
         }
         if (baseChar == 'g') {

--- a/src/main/java/org/gedcom4j/io/AnselMapping.java
+++ b/src/main/java/org/gedcom4j/io/AnselMapping.java
@@ -34,6 +34,23 @@ import java.util.Map.Entry;
 final class AnselMapping {
 
     /**
+     * The encoding mapping from characters to arrays of byte
+     */
+    static Map<Character, Character> charToByte = new HashMap<Character, Character>();
+
+    /**
+     * The encoding mapping from characters to arrays of byte
+     */
+    static Map<Character, Character> byteToChar = new HashMap<Character, Character>();
+
+    /**
+     * Private constructor prevents instantiation and subclassing
+     */
+    private AnselMapping() {
+        super();
+    }
+
+    /**
      * Decode an ANSEL byte into a UTF-16 Character
      * 
      * @param b
@@ -77,16 +94,6 @@ final class AnselMapping {
     public static boolean isUnicodeCombiningDiacritic(char c) {
         return (c >= 0x0300 && c <= 0x0333) || (c >= 0xFE20 && c <= 0xFE23);
     }
-
-    /**
-     * The encoding mapping from characters to arrays of byte
-     */
-    static Map<Character, Character> charToByte = new HashMap<Character, Character>();
-
-    /**
-     * The encoding mapping from characters to arrays of byte
-     */
-    static Map<Character, Character> byteToChar = new HashMap<Character, Character>();
 
     static {
         // latin capital letter L with stroke
@@ -303,13 +310,6 @@ final class AnselMapping {
         for (Entry<Character, Character> e : charToByte.entrySet()) {
             byteToChar.put(e.getValue(), e.getKey());
         }
-    }
-
-    /**
-     * Private constructor prevents instantiation and subclassing
-     */
-    private AnselMapping() {
-        super();
     }
 
 }

--- a/src/main/java/org/gedcom4j/io/Encoding.java
+++ b/src/main/java/org/gedcom4j/io/Encoding.java
@@ -55,6 +55,26 @@ public enum Encoding {
      */
     UTF_8("UTF-8");
 
+
+    /**
+     * The character set name found in the GEDCOM that represents a character
+     * set encoding. Note that multiple instances of this enum can share the
+     * same value for this field.
+     */
+    private String characterSetName;
+
+    /**
+     * Constructor
+     *
+     * @param characterSetName
+     *            the character set name in the GEDCOM that corresponds to this
+     *            Encoding object. Note that this value will not be unique among
+     *            instances in the enum.
+     */
+    private Encoding(String characterSetName) {
+        this.characterSetName = characterSetName;
+    }
+
     /**
      * Get an alphabetically sorted set of supported character set names
      * 
@@ -83,25 +103,6 @@ public enum Encoding {
             }
         }
         return false;
-    }
-
-    /**
-     * The character set name found in the GEDCOM that represents a character
-     * set encoding. Note that multiple instances of this enum can share the
-     * same value for this field.
-     */
-    private String characterSetName;
-
-    /**
-     * Constructor
-     * 
-     * @param characterSetName
-     *            the character set name in the GEDCOM that corresponds to this
-     *            Encoding object. Note that this value will not be unique among
-     *            instances in the enum.
-     */
-    private Encoding(String characterSetName) {
-        this.characterSetName = characterSetName;
     }
 
     /**

--- a/src/main/java/org/gedcom4j/io/GedcomFileReader.java
+++ b/src/main/java/org/gedcom4j/io/GedcomFileReader.java
@@ -98,7 +98,7 @@ public class GedcomFileReader {
     long firstNBytes(int n) {
         long result = 0;
         for (int i = 0; i < n; i++) {
-            result = ((result << 8) + (firstChunk[i] & 0xFF)); // Shift existing bits 8 to the left, and AND in this
+            result = (result << 8) + (firstChunk[i] & 0xFF); // Shift existing bits 8 to the left, and AND in this
                                                                // byte
         }
         return result;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava