### PR TITLE
Multiple code improvements - squid:S2131, squid:S1213, squid:S1862

### DIFF
--- a/src/main/java/org/gedcom4j/parser/GedcomParser.java
+++ b/src/main/java/org/gedcom4j/parser/GedcomParser.java
@@ -1104,8 +1104,6 @@ public class GedcomParser {
                 loadMultimediaLink(ch, a.multimedia);
             } else if (Tag.NOTE.equals(ch.tag)) {
                 loadNote(ch, a.notes);
-            } else if (Tag.SOURCE.equals(ch.tag)) {
-                loadCitation(ch, a.citations);
             } else if (Tag.CONCATENATION.equals(ch.tag)) {
                 if (a.description == null) {
                     a.description = new StringWithCustomTags(ch);
@@ -1722,9 +1720,6 @@ public class GedcomParser {
                 loadUserReference(ch, u);
             } else if (Tag.RECORD_ID_NUMBER.equals(ch.tag)) {
                 r.recIdNumber = new StringWithCustomTags(ch);
-            } else if (Tag.CHANGED_DATETIME.equals(ch.tag)) {
-                r.changeDate = new ChangeDate();
-                loadChangeDate(ch, r.changeDate);
             } else if (Tag.CHANGED_DATETIME.equals(ch.tag)) {
                 r.changeDate = new ChangeDate();
                 loadChangeDate(ch, r.changeDate);

--- a/src/main/java/org/gedcom4j/parser/GedcomParserHelper.java
+++ b/src/main/java/org/gedcom4j/parser/GedcomParserHelper.java
@@ -39,6 +39,13 @@ import org.gedcom4j.model.StringTree;
 final class GedcomParserHelper {
 
     /**
+     * Utility class, so prevent instantiation (and thus subclassing)
+     */
+    private GedcomParserHelper() {
+        // Do nothing
+    }
+
+    /**
      * Trim all whitespace off the left side (only) of the supplied string.
      * 
      * @param line
@@ -185,13 +192,6 @@ final class GedcomParserHelper {
             }
         }
         return result;
-    }
-
-    /**
-     * Utility class, so prevent instantiation (and thus subclassing)
-     */
-    private GedcomParserHelper() {
-        // Do nothing
     }
 
 }

--- a/src/main/java/org/gedcom4j/parser/LinePieces.java
+++ b/src/main/java/org/gedcom4j/parser/LinePieces.java
@@ -66,7 +66,7 @@ class LinePieces {
                 if (id == null) {
                     id = String.valueOf(line.charAt(c++));
                 } else {
-                    id += line.charAt(c++);
+                    id += String.valueOf(line.charAt(c++));
                 }
             }
             c++;
@@ -77,7 +77,7 @@ class LinePieces {
             if (tag == null) {
                 tag = String.valueOf(line.charAt(c++));
             } else {
-                tag += line.charAt(c++);
+                tag += String.valueOf(line.charAt(c++));
             }
         }
 

--- a/src/main/java/org/gedcom4j/relationship/SimplificationRules.java
+++ b/src/main/java/org/gedcom4j/relationship/SimplificationRules.java
@@ -31,6 +31,15 @@ import java.util.List;
  */
 final class SimplificationRules {
 
+    static List<RelationshipName[]> rules = new ArrayList<RelationshipName[]>();
+
+    /**
+     * Private constructor prevents instantiation or subclassing
+     */
+    private SimplificationRules() {
+        super();
+    }
+
     /**
      * Load the rules for aunts, uncles, nieces, and nephews
      */
@@ -331,7 +340,6 @@ final class SimplificationRules {
      * previous relationship simplifications should appear later in the list.
      * </p>
      */
-    static List<RelationshipName[]> rules = new ArrayList<RelationshipName[]>();
 
     /* static initializer to load the list */
     static {
@@ -345,13 +353,6 @@ final class SimplificationRules {
         firstCousins();
         greatAuntsUnclesNiecesNephews();
         greatGreatAuntsUnclesNiecesNephews();
-    }
-
-    /**
-     * Private constructor prevents instantiation or subclassing
-     */
-    private SimplificationRules() {
-        super();
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1862 - Conditions in related "if/else if" statements should not have the same condition.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1862
Please let me know if you have any questions.
George Kankava