### PR TITLE
Multiple code improvements - squid:S2160, squid:S2184, squid:S2391

### DIFF
--- a/src/main/java/org/gedcom4j/model/AbstractCitation.java
+++ b/src/main/java/org/gedcom4j/model/AbstractCitation.java
@@ -37,4 +37,15 @@ public abstract class AbstractCitation extends AbstractElement {
      */
     public List<Note> notes = new ArrayList<Note>();
 
+    @Override
+    public boolean equals(Object obj) {
+        if (!super.equals(obj)) {
+            return false;
+        }
+        AbstractCitation abstractCitation = (AbstractCitation) obj;
+        if(notes.equals(abstractCitation.notes)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/gedcom4j/relationship/Relationship.java
+++ b/src/main/java/org/gedcom4j/relationship/Relationship.java
@@ -87,7 +87,7 @@ public class Relationship implements Comparable<Relationship> {
         if (other == null) {
             return 1;
         }
-        return Math.round(Math.signum(chain.size() - other.chain.size()));
+        return Math.round(Math.signum((float)chain.size() - other.chain.size()));
     }
 
     @Override

--- a/src/test/java/org/gedcom4j/parser/FamilyEventTypeParseTest.java
+++ b/src/test/java/org/gedcom4j/parser/FamilyEventTypeParseTest.java
@@ -70,7 +70,7 @@ public class FamilyEventTypeParseTest extends TestCase {
      *             if there is an error reading the data
      */
     @Override
-    protected void setUp() throws IOException, GedcomParserException {
+    public void setUp() throws IOException, GedcomParserException {
         GedcomParser gp = new GedcomParser();
         gp.load("sample/TGC551.ged");
         assertTrue(gp.errors.isEmpty());

--- a/src/test/java/org/gedcom4j/validate/AbstractValidatorTestCase.java
+++ b/src/test/java/org/gedcom4j/validate/AbstractValidatorTestCase.java
@@ -137,7 +137,7 @@ public abstract class AbstractValidatorTestCase extends TestCase {
      * {@inheritDoc}
      */
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         gedcom = new Gedcom();
         rootValidator = new GedcomValidator(gedcom);

--- a/src/test/java/org/gedcom4j/validate/GedcomValidatorTest.java
+++ b/src/test/java/org/gedcom4j/validate/GedcomValidatorTest.java
@@ -147,7 +147,7 @@ public class GedcomValidatorTest extends AbstractValidatorTestCase {
     }
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 

--- a/src/test/java/org/gedcom4j/validate/IndividualValidatorTest.java
+++ b/src/test/java/org/gedcom4j/validate/IndividualValidatorTest.java
@@ -78,7 +78,7 @@ public class IndividualValidatorTest extends AbstractValidatorTestCase {
     }
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
     }
 

--- a/src/test/java/org/gedcom4j/writer/GedcomWriterTest.java
+++ b/src/test/java/org/gedcom4j/writer/GedcomWriterTest.java
@@ -301,7 +301,7 @@ public class GedcomWriterTest extends TestCase {
      *             if anything goes wrong
      */
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         // Make sure we actually have test fixtures to work with
         assertNotNull(gedcomOrig);
         assertNotNull(gedcomReadback);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2160 - Subclasses that add fields should override "equals".
squid:S2184 - Math operands should be cast before assignment.
squid:S2391 - JUnit framework methods should be declared properly.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2160
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:S2391
Please let me know if you have any questions.
George Kankava