### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/gedcom4j/model/FamilyEventType.java
+++ b/src/main/java/org/gedcom4j/model/FamilyEventType.java
@@ -74,6 +74,29 @@ public enum FamilyEventType {
     EVENT("EVEN", "Event");
 
     /**
+     * The tag
+     */
+    public final String tag;
+
+    /**
+     * The display value for the tag
+     */
+    public final String display;
+
+    /**
+     * Constructor
+     *
+     * @param tag
+     *            the tag for the enum constant
+     * @param display
+     *            the display value for the enum constant
+     */
+    private FamilyEventType(String tag, String display) {
+        this.tag = tag;
+        this.display = display;
+    }
+
+    /**
      * Get an enum type from its tag string
      * 
      * @param tag
@@ -98,29 +121,6 @@ public enum FamilyEventType {
      */
     public static boolean isValidTag(String tag) {
         return getFromTag(tag) != null;
-    }
-
-    /**
-     * The tag
-     */
-    public final String tag;
-
-    /**
-     * The display value for the tag
-     */
-    public final String display;
-
-    /**
-     * Constructor
-     * 
-     * @param tag
-     *            the tag for the enum constant
-     * @param display
-     *            the display value for the enum constant
-     */
-    private FamilyEventType(String tag, String display) {
-        this.tag = tag;
-        this.display = display;
     }
 
 }

--- a/src/main/java/org/gedcom4j/model/IndividualAttributeType.java
+++ b/src/main/java/org/gedcom4j/model/IndividualAttributeType.java
@@ -89,6 +89,29 @@ public enum IndividualAttributeType {
     FACT("FACT", "Fact");
 
     /**
+     * The tag
+     */
+    public final String tag;
+
+    /**
+     * The display value for the type
+     */
+    public final String display;
+
+    /**
+     * Constructor
+     *
+     * @param tag
+     *            the tag
+     * @param display
+     *            the display value
+     */
+    private IndividualAttributeType(String tag, String display) {
+        this.tag = tag;
+        this.display = display;
+    }
+
+    /**
      * Get an enum constant from its tag value
      * 
      * @param tag
@@ -113,28 +136,5 @@ public enum IndividualAttributeType {
      */
     public static boolean isValidTag(String tag) {
         return getFromTag(tag) != null;
-    }
-
-    /**
-     * The tag
-     */
-    public final String tag;
-
-    /**
-     * The display value for the type
-     */
-    public final String display;
-
-    /**
-     * Constructor
-     * 
-     * @param tag
-     *            the tag
-     * @param display
-     *            the display value
-     */
-    private IndividualAttributeType(String tag, String display) {
-        this.tag = tag;
-        this.display = display;
     }
 }

--- a/src/main/java/org/gedcom4j/model/IndividualEventType.java
+++ b/src/main/java/org/gedcom4j/model/IndividualEventType.java
@@ -126,6 +126,29 @@ public enum IndividualEventType {
     EVENT("EVEN", "Event");
 
     /**
+     * The tag
+     */
+    public final String tag;
+
+    /**
+     * The display value
+     */
+    public final String display;
+
+    /**
+     * Private constructor
+     *
+     * @param tag
+     *            the tag
+     * @param display
+     *            the display value
+     */
+    private IndividualEventType(String tag, String display) {
+        this.tag = tag;
+        this.display = display;
+    }
+
+    /**
      * Get an individual event type enum constant from its tag
      * 
      * @param tag
@@ -152,26 +175,4 @@ public enum IndividualEventType {
         return getFromTag(tag) != null;
     }
 
-    /**
-     * The tag
-     */
-    public final String tag;
-
-    /**
-     * The display value
-     */
-    public final String display;
-
-    /**
-     * Private constructor
-     * 
-     * @param tag
-     *            the tag
-     * @param display
-     *            the display value
-     */
-    private IndividualEventType(String tag, String display) {
-        this.tag = tag;
-        this.display = display;
-    }
 }

--- a/src/main/java/org/gedcom4j/model/LdsIndividualOrdinanceType.java
+++ b/src/main/java/org/gedcom4j/model/LdsIndividualOrdinanceType.java
@@ -46,6 +46,29 @@ public enum LdsIndividualOrdinanceType {
     CHILD_SEALING("SLGC", "LDS Child Sealing");
 
     /**
+     * The tag
+     */
+    public final String tag;
+
+    /**
+     * The display value
+     */
+    public final String display;
+
+    /**
+     * Contructor
+     *
+     * @param tag
+     *            the tag
+     * @param display
+     *            the display value
+     */
+    private LdsIndividualOrdinanceType(String tag, String display) {
+        this.tag = tag;
+        this.display = display;
+    }
+
+    /**
      * Get an enum constant from the tag it corresponds to
      * 
      * @param tag
@@ -70,28 +93,5 @@ public enum LdsIndividualOrdinanceType {
      */
     public static boolean isValidTag(String tag) {
         return getFromTag(tag) != null;
-    }
-
-    /**
-     * The tag
-     */
-    public final String tag;
-
-    /**
-     * The display value
-     */
-    public final String display;
-
-    /**
-     * Contructor
-     * 
-     * @param tag
-     *            the tag
-     * @param display
-     *            the display value
-     */
-    private LdsIndividualOrdinanceType(String tag, String display) {
-        this.tag = tag;
-        this.display = display;
     }
 }

--- a/src/main/java/org/gedcom4j/model/SupportedVersion.java
+++ b/src/main/java/org/gedcom4j/model/SupportedVersion.java
@@ -38,6 +38,21 @@ public enum SupportedVersion {
     V5_5_1("5.5.1");
 
     /**
+     * The string representation of the version
+     */
+    private String stringRepresentation;
+
+    /**
+     * Constructor that takes the string representation as a parameter
+     *
+     * @param stringRep
+     *            the string representation of the version
+     */
+    SupportedVersion(String stringRep) {
+        stringRepresentation = stringRep;
+    }
+
+    /**
      * Get the SupportedVersion instance that matches the supplied string
      * 
      * @param string
@@ -54,21 +69,6 @@ public enum SupportedVersion {
             return V5_5_1;
         }
         throw new UnsupportedVersionException("Unsupported version: " + string);
-    }
-
-    /**
-     * The string representation of the version
-     */
-    private String stringRepresentation;
-
-    /**
-     * Constructor that takes the string representation as a parameter
-     * 
-     * @param stringRep
-     *            the string representation of the version
-     */
-    SupportedVersion(String stringRep) {
-        stringRepresentation = stringRep;
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava