### PR TITLE
improve code coverage of testValues() copyConstructor tests for LdsOrdinance subclasses

### DIFF
--- a/src/test/java/org/gedcom4j/model/LdsIndividualOrdinanceCopyTest.java
+++ b/src/test/java/org/gedcom4j/model/LdsIndividualOrdinanceCopyTest.java
@@ -67,6 +67,9 @@ public class LdsIndividualOrdinanceCopyTest extends AbstractCopyTest {
     public void testValues() {
         LdsIndividualOrdinance orig = new LdsIndividualOrdinance();
         orig.setDate("A");
+        orig.setTemple("T");
+        orig.getCitations(true).add(new CitationWithoutSource());
+        orig.getCitations(true).add(new CitationWithSource());
         FamilyChild fc = new FamilyChild();
         fc.setStatus("B");
         fc.setPedigree("C");
@@ -81,7 +84,7 @@ public class LdsIndividualOrdinanceCopyTest extends AbstractCopyTest {
         assertEquals(orig.toString(), copy.toString());
 
         orig.getFamilyWhereChild().setAdoptedBy((String) null);
-        assertFalse("Copy shoul not match if original is changed", orig.equals(copy));
+        assertFalse("Copy should not match if original is changed", orig.equals(copy));
     }
 
 }

--- a/src/test/java/org/gedcom4j/model/LdsSpouseSealingCopyTest.java
+++ b/src/test/java/org/gedcom4j/model/LdsSpouseSealingCopyTest.java
@@ -70,6 +70,9 @@ public class LdsSpouseSealingCopyTest extends AbstractCopyTest {
         orig.setPlace("B");
         orig.setStatus("C");
         orig.setStatus("D");
+        orig.setTemple("E");
+        orig.getCitations(true).add(new CitationWithoutSource());
+        orig.getCitations(true).add(new CitationWithSource());
         orig.getNoteStructures(true);
         orig.customFacts = null;
 


### PR DESCRIPTION
Modifies testValues test for LdsIndividualOrdinanceCopyTest and LdsSpouseSealingCopyTest to copy citation and temple values, improving test code coverage of the AbstractLdsOrdinance copy constructor. Also fixes typo in testValues test for LdsIndividualOrdinanceCopyTest.