### PR TITLE
Tests for Status Enums

### DIFF
--- a/src/main/java/org/gedcom4j/model/enumerations/LdsChildSealingDateStatus.java
+++ b/src/main/java/org/gedcom4j/model/enumerations/LdsChildSealingDateStatus.java
@@ -34,7 +34,7 @@ package org.gedcom4j.model.enumerations;
 public enum LdsChildSealingDateStatus {
 
     /** Born in covenant */
-    BIC("BIC", "Born in the covenant receiving blessing of child to parent sealing"),
+    BIC("BIC", "Born in the covenant receiving blessing of child to parent sealing."),
 
     /** completed */
     COMPLETED("COMPLETED", "Completed but the date is not known."),
@@ -43,7 +43,7 @@ public enum LdsChildSealingDateStatus {
     EXCLUDED("EXCLUDED", "Patron excluded this ordinance from being cleared in this submission."),
 
     /** Do not submit */
-    DNS("DNS", "This ordinance is not authorized"),
+    DNS("DNS", "This ordinance is not authorized."),
 
     /** pre 1970 */
     PRE_1970("PRE-1970", "Ordinance from temple records of work completed before 1970, assumed complete."),

--- a/src/main/java/org/gedcom4j/model/enumerations/LdsSpouseSealingDateStatus.java
+++ b/src/main/java/org/gedcom4j/model/enumerations/LdsSpouseSealingDateStatus.java
@@ -35,21 +35,21 @@ import org.gedcom4j.model.LdsSpouseSealing;
  */
 public enum LdsSpouseSealingDateStatus {
     /** Cancelled */
-    CANCELED("CANCELED", "Canceled and considered invalid"),
+    CANCELED("CANCELED", "Canceled and considered invalid."),
     /** Completed */
-    COMPLETED("COMPLETED", "Completed but the date is not known"),
+    COMPLETED("COMPLETED", "Completed but the date is not known."),
     /** Excluded from submission */
-    EXCLUDED("EXCLUDED", "Patron excluded this ordinance from being cleared in this submission"),
+    EXCLUDED("EXCLUDED", "Patron excluded this ordinance from being cleared in this submission."),
     /** Do not submit - not authorized */
-    DNS("DNS", "This ordinance is not authorized"),
+    DNS("DNS", "This ordinance is not authorized."),
     /** Not authorized, previous sealing cancelled */
-    DNS_CAN("DNS/CAN", "This ordinance is not authorized, previous sealing cancelled"),
+    DNS_CAN("DNS/CAN", "This ordinance is not authorized, previous sealing cancelled."),
     /** Pre-1970 so assumed complete */
-    PRE_1970("PRE-1970", "From before 1970, assumed complete"),
+    PRE_1970("PRE-1970", "From before 1970, assumed complete."),
     /** Previously submitted */
-    SUBMITTED("SUBMITTED", "Ordinance was previously submitted"),
+    SUBMITTED("SUBMITTED", "Ordinance was previously submitted."),
     /** Not cleared (insufficient data) */
-    UNCLEARED("UNCLEARED", "Data for clearing ordinance request was insufficient");
+    UNCLEARED("UNCLEARED", "Data for clearing ordinance request was insufficient.");
 
     /**
      * Gets the value by its code

--- a/src/test/java/org/gedcom4j/model/enumerations/ChildLinkageStatusTest.java
+++ b/src/test/java/org/gedcom4j/model/enumerations/ChildLinkageStatusTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2009-2016 Matthew R. Harrah
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.gedcom4j.model.enumerations;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link ChildLinkageStatus}
+ * 
+ * @author reckenrod
+ */
+public class ChildLinkageStatusTest {
+
+    /**
+     * Test for {@link ChildLinkageStatus#getForCode(String)}
+     */
+    @Test
+    public void testGetForCode() {
+        assertSame(ChildLinkageStatus.CHALLENGED, ChildLinkageStatus.getForCode("challenged"));
+        assertSame(ChildLinkageStatus.DISPROVEN, ChildLinkageStatus.getForCode("disproven"));
+        assertSame(ChildLinkageStatus.PROVEN, ChildLinkageStatus.getForCode("proven"));
+        assertNull(ChildLinkageStatus.getForCode("BAD"));
+        assertNull(ChildLinkageStatus.getForCode(null));
+        assertNull(ChildLinkageStatus.getForCode(""));
+    }
+    
+    /**
+     * Test for {@link ChildLinkageStatus#getCode()}
+     */
+    @Test
+    public void testGetCode() {
+        assertSame(ChildLinkageStatus.CHALLENGED.getCode(), "challenged");
+        assertSame(ChildLinkageStatus.DISPROVEN.getCode(), "disproven");
+        assertSame(ChildLinkageStatus.PROVEN.getCode(), "proven");
+    }
+    
+    /**
+     * Test for {@link ChildLinkageStatus#getDescription()}
+     */
+    @Test
+    public void testGetDescription() {
+        assertSame(ChildLinkageStatus.CHALLENGED.getDescription(), "suspect but not proven or disproven");
+        assertSame(ChildLinkageStatus.DISPROVEN.getDescription(), "there has been a challenge but linkage was disproven");
+        assertSame(ChildLinkageStatus.PROVEN.getDescription(), "there has been a challenge but linkage was proven");
+    }
+    
+    /**
+     * Test for {@link ChildLinkageStatus#toString()}
+     */
+    @Test
+    public void testToString() {
+        assertSame(ChildLinkageStatus.CHALLENGED.getCode(), ChildLinkageStatus.CHALLENGED.toString());
+        assertSame(ChildLinkageStatus.DISPROVEN.getCode(), ChildLinkageStatus.DISPROVEN.toString());
+        assertSame(ChildLinkageStatus.PROVEN.getCode(), ChildLinkageStatus.PROVEN.toString());
+    }
+}

--- a/src/test/java/org/gedcom4j/model/enumerations/LdsBaptismDateStatusTest.java
+++ b/src/test/java/org/gedcom4j/model/enumerations/LdsBaptismDateStatusTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2009-2016 Matthew R. Harrah
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.gedcom4j.model.enumerations;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link LdsBaptismDateStatus}
+ * 
+ * @author reckenrod
+ */
+public class LdsBaptismDateStatusTest {
+
+    /**
+     * Test for {@link LdsBaptismDateStatus#getForCode(String)}
+     */
+    @Test
+    public void testGetForCode() {
+        assertSame(LdsBaptismDateStatus.CHILD, LdsBaptismDateStatus.getForCode("CHILD"));
+        assertSame(LdsBaptismDateStatus.COMPLETED, LdsBaptismDateStatus.getForCode("COMPLETED"));
+        assertSame(LdsBaptismDateStatus.EXCLUDED, LdsBaptismDateStatus.getForCode("EXCLUDED"));
+        assertSame(LdsBaptismDateStatus.PRE_1970, LdsBaptismDateStatus.getForCode("PRE-1970"));
+        assertSame(LdsBaptismDateStatus.STILLBORN, LdsBaptismDateStatus.getForCode("STILLBORN"));
+        assertSame(LdsBaptismDateStatus.SUBMITTED, LdsBaptismDateStatus.getForCode("SUBMITTED"));
+        assertSame(LdsBaptismDateStatus.UNCLEARED, LdsBaptismDateStatus.getForCode("UNCLEARED"));
+        assertNull(LdsBaptismDateStatus.getForCode("BAD"));
+        assertNull(LdsBaptismDateStatus.getForCode(null));
+        assertNull(LdsBaptismDateStatus.getForCode(""));
+    }
+    
+    /**
+     * Test for {@link LdsBaptismDateStatus#getCode()}
+     */
+    @Test
+    public void testGetCode() {
+        assertSame(LdsBaptismDateStatus.CHILD.getCode(), "CHILD");
+        assertSame(LdsBaptismDateStatus.COMPLETED.getCode(), "COMPLETED");
+        assertSame(LdsBaptismDateStatus.EXCLUDED.getCode(), "EXCLUDED");
+        assertSame(LdsBaptismDateStatus.PRE_1970.getCode(), "PRE-1970");
+        assertSame(LdsBaptismDateStatus.STILLBORN.getCode(), "STILLBORN");
+        assertSame(LdsBaptismDateStatus.SUBMITTED.getCode(), "SUBMITTED");
+        assertSame(LdsBaptismDateStatus.UNCLEARED.getCode(), "UNCLEARED");
+    }
+    
+    /**
+     * Test for {@link LdsBaptismDateStatus#getDescription()}
+     */
+    @Test
+    public void testGetDescription() {
+        assertSame(LdsBaptismDateStatus.CHILD.getDescription(), "Died before becoming eight years old, baptism not required.");
+        assertSame(LdsBaptismDateStatus.COMPLETED.getDescription(), "Completed but the date is not known.");
+        assertSame(LdsBaptismDateStatus.EXCLUDED.getDescription(), "Patron excluded this ordinance from being cleared in this submission.");
+        assertSame(LdsBaptismDateStatus.PRE_1970.getDescription(), "Ordinance from temple records of work completed before 1970, assumed complete.");
+        assertSame(LdsBaptismDateStatus.STILLBORN.getDescription(), "Stillborn, baptism not required.");
+        assertSame(LdsBaptismDateStatus.SUBMITTED.getDescription(), "Ordinance was previously submitted.");
+        assertSame(LdsBaptismDateStatus.UNCLEARED.getDescription(), "Data for clearing ordinance request was insufficient.");
+    }
+    
+    /**
+     * Test for {@link LdsBaptismDateStatus#toString()}
+     */
+    @Test
+    public void testToString() {
+        assertSame(LdsBaptismDateStatus.CHILD.getCode(), LdsBaptismDateStatus.CHILD.toString());
+        assertSame(LdsBaptismDateStatus.COMPLETED.getCode(), LdsBaptismDateStatus.COMPLETED.toString());
+        assertSame(LdsBaptismDateStatus.EXCLUDED.getCode(), LdsBaptismDateStatus.EXCLUDED.toString());
+        assertSame(LdsBaptismDateStatus.PRE_1970.getCode(), LdsBaptismDateStatus.PRE_1970.toString());
+        assertSame(LdsBaptismDateStatus.STILLBORN.getCode(), LdsBaptismDateStatus.STILLBORN.toString());
+        assertSame(LdsBaptismDateStatus.SUBMITTED.getCode(), LdsBaptismDateStatus.SUBMITTED.toString());
+        assertSame(LdsBaptismDateStatus.UNCLEARED.getCode(), LdsBaptismDateStatus.UNCLEARED.toString());
+    }
+}

--- a/src/test/java/org/gedcom4j/model/enumerations/LdsChildSealingDateStatusTest.java
+++ b/src/test/java/org/gedcom4j/model/enumerations/LdsChildSealingDateStatusTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2009-2016 Matthew R. Harrah
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.gedcom4j.model.enumerations;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link LdsChildSealingDateStatus}
+ * 
+ * @author reckenrod
+ */
+public class LdsChildSealingDateStatusTest {
+
+    /**
+     * Test for {@link LdsChildSealingDateStatus#getForCode(String)}
+     */
+    @Test
+    public void testGetForCode() {
+        assertSame(LdsChildSealingDateStatus.BIC, LdsChildSealingDateStatus.getForCode("BIC"));
+        assertSame(LdsChildSealingDateStatus.COMPLETED, LdsChildSealingDateStatus.getForCode("COMPLETED"));
+        assertSame(LdsChildSealingDateStatus.DNS, LdsChildSealingDateStatus.getForCode("DNS"));
+        assertSame(LdsChildSealingDateStatus.EXCLUDED, LdsChildSealingDateStatus.getForCode("EXCLUDED"));
+        assertSame(LdsChildSealingDateStatus.PRE_1970, LdsChildSealingDateStatus.getForCode("PRE-1970"));
+        assertSame(LdsChildSealingDateStatus.STILLBORN, LdsChildSealingDateStatus.getForCode("STILLBORN"));
+        assertSame(LdsChildSealingDateStatus.SUBMITTED, LdsChildSealingDateStatus.getForCode("SUBMITTED"));
+        assertSame(LdsChildSealingDateStatus.UNCLEARED, LdsChildSealingDateStatus.getForCode("UNCLEARED"));
+        assertNull(LdsChildSealingDateStatus.getForCode("BAD"));
+        assertNull(LdsChildSealingDateStatus.getForCode(null));
+        assertNull(LdsChildSealingDateStatus.getForCode(""));
+    }
+    
+    /**
+     * Test for {@link LdsChildSealingDateStatus#getCode()}
+     */
+    @Test
+    public void testGetCode() {
+        assertSame(LdsChildSealingDateStatus.BIC.getCode(), "BIC");
+        assertSame(LdsChildSealingDateStatus.COMPLETED.getCode(), "COMPLETED");
+        assertSame(LdsChildSealingDateStatus.EXCLUDED.getCode(), "EXCLUDED");
+        assertSame(LdsChildSealingDateStatus.DNS.getCode(), "DNS");
+        assertSame(LdsChildSealingDateStatus.PRE_1970.getCode(), "PRE-1970");
+        assertSame(LdsChildSealingDateStatus.STILLBORN.getCode(), "STILLBORN");
+        assertSame(LdsChildSealingDateStatus.SUBMITTED.getCode(), "SUBMITTED");
+        assertSame(LdsChildSealingDateStatus.UNCLEARED.getCode(), "UNCLEARED");
+    }
+    
+    /**
+     * Test for {@link LdsChildSealingDateStatus#getDescription()}
+     */
+    @Test
+    public void testGetDescription() {
+        assertSame(LdsChildSealingDateStatus.BIC.getDescription(), "Born in the covenant receiving blessing of child to parent sealing.");
+        assertSame(LdsChildSealingDateStatus.COMPLETED.getDescription(), "Completed but the date is not known.");
+        assertSame(LdsChildSealingDateStatus.EXCLUDED.getDescription(), "Patron excluded this ordinance from being cleared in this submission.");
+        assertSame(LdsChildSealingDateStatus.DNS.getDescription(), "This ordinance is not authorized.");
+        assertSame(LdsChildSealingDateStatus.PRE_1970.getDescription(), "Ordinance from temple records of work completed before 1970, assumed complete.");
+        assertSame(LdsChildSealingDateStatus.STILLBORN.getDescription(), "Stillborn, baptism not required.");
+        assertSame(LdsChildSealingDateStatus.SUBMITTED.getDescription(), "Ordinance was previously submitted.");
+        assertSame(LdsChildSealingDateStatus.UNCLEARED.getDescription(), "Data for clearing ordinance request was insufficient.");
+    }
+    
+    /**
+     * Test for {@link LdsChildSealingDateStatus#toString()}
+     */
+    @Test
+    public void testToString() {
+        assertSame(LdsChildSealingDateStatus.BIC.getCode(), LdsChildSealingDateStatus.BIC.toString());
+        assertSame(LdsChildSealingDateStatus.COMPLETED.getCode(), LdsChildSealingDateStatus.COMPLETED.toString());
+        assertSame(LdsChildSealingDateStatus.EXCLUDED.getCode(), LdsChildSealingDateStatus.EXCLUDED.toString());
+        assertSame(LdsChildSealingDateStatus.DNS.getCode(), LdsChildSealingDateStatus.DNS.toString());
+        assertSame(LdsChildSealingDateStatus.PRE_1970.getCode(), LdsChildSealingDateStatus.PRE_1970.toString());
+        assertSame(LdsChildSealingDateStatus.STILLBORN.getCode(), LdsChildSealingDateStatus.STILLBORN.toString());
+        assertSame(LdsChildSealingDateStatus.SUBMITTED.getCode(), LdsChildSealingDateStatus.SUBMITTED.toString());
+        assertSame(LdsChildSealingDateStatus.UNCLEARED.getCode(), LdsChildSealingDateStatus.UNCLEARED.toString());
+    }
+}

--- a/src/test/java/org/gedcom4j/model/enumerations/LdsEndowmentDateStatusTest.java
+++ b/src/test/java/org/gedcom4j/model/enumerations/LdsEndowmentDateStatusTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2009-2016 Matthew R. Harrah
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.gedcom4j.model.enumerations;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link LdsEndowmentDateStatus}
+ * 
+ * @author reckenrod
+ */
+public class LdsEndowmentDateStatusTest {
+
+    /**
+     * Test for {@link LdsEndowmentDateStatus#getForCode(String)}
+     */
+    @Test
+    public void testGetForCode() {
+        assertSame(LdsEndowmentDateStatus.CHILD, LdsEndowmentDateStatus.getForCode("CHILD"));
+        assertSame(LdsEndowmentDateStatus.COMPLETED, LdsEndowmentDateStatus.getForCode("COMPLETED"));
+        assertSame(LdsEndowmentDateStatus.EXCLUDED, LdsEndowmentDateStatus.getForCode("EXCLUDED"));
+        assertSame(LdsEndowmentDateStatus.PRE_1970, LdsEndowmentDateStatus.getForCode("PRE-1970"));
+        assertSame(LdsEndowmentDateStatus.STILLBORN, LdsEndowmentDateStatus.getForCode("STILLBORN"));
+        assertSame(LdsEndowmentDateStatus.SUBMITTED, LdsEndowmentDateStatus.getForCode("SUBMITTED"));
+        assertSame(LdsEndowmentDateStatus.UNCLEARED, LdsEndowmentDateStatus.getForCode("UNCLEARED"));
+        assertNull(LdsEndowmentDateStatus.getForCode("BAD"));
+        assertNull(LdsEndowmentDateStatus.getForCode(null));
+        assertNull(LdsEndowmentDateStatus.getForCode(""));
+    }
+    
+    /**
+     * Test for {@link LdsEndowmentDateStatus#getCode()}
+     */
+    @Test
+    public void testGetCode() {
+        assertSame(LdsEndowmentDateStatus.CHILD.getCode(), "CHILD");
+        assertSame(LdsEndowmentDateStatus.COMPLETED.getCode(), "COMPLETED");
+        assertSame(LdsEndowmentDateStatus.EXCLUDED.getCode(), "EXCLUDED");
+        assertSame(LdsEndowmentDateStatus.PRE_1970.getCode(), "PRE-1970");
+        assertSame(LdsEndowmentDateStatus.STILLBORN.getCode(), "STILLBORN");
+        assertSame(LdsEndowmentDateStatus.SUBMITTED.getCode(), "SUBMITTED");
+        assertSame(LdsEndowmentDateStatus.UNCLEARED.getCode(), "UNCLEARED");
+    }
+    
+    /**
+     * Test for {@link LdsEndowmentDateStatus#getDescription()}
+     */
+    @Test
+    public void testGetDescription() {
+        assertSame(LdsEndowmentDateStatus.CHILD.getDescription(), "Died before becoming eight years old.");
+        assertSame(LdsEndowmentDateStatus.COMPLETED.getDescription(), "Completed but the date is not known.");
+        assertSame(LdsEndowmentDateStatus.EXCLUDED.getDescription(), "Patron excluded this ordinance from being cleared in this submission.");
+        assertSame(LdsEndowmentDateStatus.PRE_1970.getDescription(), "Ordinance from temple records of work completed before 1970, assumed complete.");
+        assertSame(LdsEndowmentDateStatus.STILLBORN.getDescription(), "Stillborn, baptism not required.");
+        assertSame(LdsEndowmentDateStatus.SUBMITTED.getDescription(), "Ordinance was previously submitted.");
+        assertSame(LdsEndowmentDateStatus.UNCLEARED.getDescription(), "Data for clearing ordinance request was insufficient.");
+    }
+    
+    /**
+     * Test for {@link LdsEndowmentDateStatus#toString()}
+     */
+    @Test
+    public void testToString() {
+        assertSame(LdsEndowmentDateStatus.CHILD.getCode(), LdsEndowmentDateStatus.CHILD.toString());
+        assertSame(LdsEndowmentDateStatus.COMPLETED.getCode(), LdsEndowmentDateStatus.COMPLETED.toString());
+        assertSame(LdsEndowmentDateStatus.EXCLUDED.getCode(), LdsEndowmentDateStatus.EXCLUDED.toString());
+        assertSame(LdsEndowmentDateStatus.PRE_1970.getCode(), LdsEndowmentDateStatus.PRE_1970.toString());
+        assertSame(LdsEndowmentDateStatus.STILLBORN.getCode(), LdsEndowmentDateStatus.STILLBORN.toString());
+        assertSame(LdsEndowmentDateStatus.SUBMITTED.getCode(), LdsEndowmentDateStatus.SUBMITTED.toString());
+        assertSame(LdsEndowmentDateStatus.UNCLEARED.getCode(), LdsEndowmentDateStatus.UNCLEARED.toString());
+    }
+}

--- a/src/test/java/org/gedcom4j/model/enumerations/LdsSpouseSealingDateStatusTest.java
+++ b/src/test/java/org/gedcom4j/model/enumerations/LdsSpouseSealingDateStatusTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2009-2016 Matthew R. Harrah
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.gedcom4j.model.enumerations;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link LdsSpouseSealingDateStatus}
+ * 
+ * @author reckenrod
+ */
+public class LdsSpouseSealingDateStatusTest {
+
+    /**
+     * Test for {@link LdsSpouseSealingDateStatus#getForCode(String)}
+     */
+    @Test
+    public void testGetForCode() {
+        assertSame(LdsSpouseSealingDateStatus.CANCELED, LdsSpouseSealingDateStatus.getForCode("CANCELED"));
+        assertSame(LdsSpouseSealingDateStatus.COMPLETED, LdsSpouseSealingDateStatus.getForCode("COMPLETED"));
+        assertSame(LdsSpouseSealingDateStatus.DNS, LdsSpouseSealingDateStatus.getForCode("DNS"));
+        assertSame(LdsSpouseSealingDateStatus.DNS_CAN, LdsSpouseSealingDateStatus.getForCode("DNS/CAN"));
+        assertSame(LdsSpouseSealingDateStatus.EXCLUDED, LdsSpouseSealingDateStatus.getForCode("EXCLUDED"));
+        assertSame(LdsSpouseSealingDateStatus.PRE_1970, LdsSpouseSealingDateStatus.getForCode("PRE-1970"));
+        assertSame(LdsSpouseSealingDateStatus.SUBMITTED, LdsSpouseSealingDateStatus.getForCode("SUBMITTED"));
+        assertSame(LdsSpouseSealingDateStatus.UNCLEARED, LdsSpouseSealingDateStatus.getForCode("UNCLEARED"));
+        assertNull(LdsSpouseSealingDateStatus.getForCode("BAD"));
+        assertNull(LdsSpouseSealingDateStatus.getForCode(null));
+        assertNull(LdsSpouseSealingDateStatus.getForCode(""));
+    }
+    
+    /**
+     * Test for {@link LdsSpouseSealingDateStatus#getCode()}
+     */
+    @Test
+    public void testGetCode() {
+        assertSame(LdsSpouseSealingDateStatus.CANCELED.getCode(), "CANCELED");
+        assertSame(LdsSpouseSealingDateStatus.COMPLETED.getCode(), "COMPLETED");
+        assertSame(LdsSpouseSealingDateStatus.EXCLUDED.getCode(), "EXCLUDED");
+        assertSame(LdsSpouseSealingDateStatus.DNS.getCode(), "DNS");
+        assertSame(LdsSpouseSealingDateStatus.DNS_CAN.getCode(), "DNS/CAN");
+        assertSame(LdsSpouseSealingDateStatus.PRE_1970.getCode(), "PRE-1970");
+        assertSame(LdsSpouseSealingDateStatus.SUBMITTED.getCode(), "SUBMITTED");
+        assertSame(LdsSpouseSealingDateStatus.UNCLEARED.getCode(), "UNCLEARED");
+    }
+    
+    /**
+     * Test for {@link LdsSpouseSealingDateStatus#getDescription()}
+     */
+    @Test
+    public void testGetDescription() {
+        assertSame(LdsSpouseSealingDateStatus.CANCELED.getDescription(), "Canceled and considered invalid.");
+        assertSame(LdsSpouseSealingDateStatus.COMPLETED.getDescription(), "Completed but the date is not known.");
+        assertSame(LdsSpouseSealingDateStatus.EXCLUDED.getDescription(), "Patron excluded this ordinance from being cleared in this submission.");
+        assertSame(LdsSpouseSealingDateStatus.DNS.getDescription(), "This ordinance is not authorized.");
+        assertSame(LdsSpouseSealingDateStatus.DNS_CAN.getDescription(), "This ordinance is not authorized, previous sealing cancelled.");
+        assertSame(LdsSpouseSealingDateStatus.PRE_1970.getDescription(), "From before 1970, assumed complete.");
+        assertSame(LdsSpouseSealingDateStatus.SUBMITTED.getDescription(), "Ordinance was previously submitted.");
+        assertSame(LdsSpouseSealingDateStatus.UNCLEARED.getDescription(), "Data for clearing ordinance request was insufficient.");
+    }
+    
+    /**
+     * Test for {@link LdsSpouseSealingDateStatus#toString()}
+     */
+    @Test
+    public void testToString() {
+        assertSame(LdsSpouseSealingDateStatus.CANCELED.getCode(), LdsSpouseSealingDateStatus.CANCELED.toString());
+        assertSame(LdsSpouseSealingDateStatus.COMPLETED.getCode(), LdsSpouseSealingDateStatus.COMPLETED.toString());
+        assertSame(LdsSpouseSealingDateStatus.EXCLUDED.getCode(), LdsSpouseSealingDateStatus.EXCLUDED.toString());
+        assertSame(LdsSpouseSealingDateStatus.DNS.getCode(), LdsSpouseSealingDateStatus.DNS.toString());
+        assertSame(LdsSpouseSealingDateStatus.DNS_CAN.getCode(), LdsSpouseSealingDateStatus.DNS_CAN.toString());
+        assertSame(LdsSpouseSealingDateStatus.PRE_1970.getCode(), LdsSpouseSealingDateStatus.PRE_1970.toString());
+        assertSame(LdsSpouseSealingDateStatus.SUBMITTED.getCode(), LdsSpouseSealingDateStatus.SUBMITTED.toString());
+        assertSame(LdsSpouseSealingDateStatus.UNCLEARED.getCode(), LdsSpouseSealingDateStatus.UNCLEARED.toString());
+    }
+}


### PR DESCRIPTION
Tests for all methods of ChildLinkageStatus and LdsDateStatus enumerations. 
Also added periods where they were missing for enum descriptions to normalize format.