### PR TITLE
unit test to ensure CONT lines have no ID

### DIFF
--- a/src/test/java/org/gedcom4j/writer/AbstractEmitterTest.java
+++ b/src/test/java/org/gedcom4j/writer/AbstractEmitterTest.java
@@ -1,0 +1,33 @@
+package org.gedcom4j.writer;
+
+import junit.framework.TestCase;
+import org.gedcom4j.exception.*;
+import org.gedcom4j.model.*;
+import org.junit.Test;
+
+import java.util.*;
+
+public class AbstractEmitterTest extends TestCase {
+    @Test
+    public void testEmitLinesOfText() throws WriterCancelledException {
+        GedcomWriter writer = new GedcomWriter(new Gedcom());
+
+        AbstractEmitter<Collection<NoteRecord>> uut =
+            new AbstractEmitter<Collection<NoteRecord>>(writer, 0, null) {
+                @Override
+                protected void emit() {
+                }
+            };
+
+        List<String> lines = new ArrayList<>();
+        lines.add("line 1");
+        lines.add("line 2");
+        lines.add("line 3");
+
+        uut.emitLinesOfText(0, "@N99@", "NOTE", lines);
+
+        assertEquals("0 @N99@ NOTE line 1", writer.lines.get(0));
+        assertEquals("1 CONT line 2", writer.lines.get(1));
+        assertEquals("1 CONT line 3", writer.lines.get(2));
+    }
+}


### PR DESCRIPTION
Test to show invalid CONT lines. See `sample/willis-ascii.ged` for examples of the effects of the defect:

```
$ grep N149 sample/willis-ascii.ged
1 NOTE @N149@
0 @N149@ NOTE 
1 @N149@ CONT 
1 @N149@ CONT 1880 Census Place: Elizabeth, Lawrence, Ohio: Plas WILLIS, Self, M, W, W, 44, Ohio, Occ: Laborer, Fa: VA, Mo: VA, 
```
Expected:
```
1 NOTE @N149@
0 @N149@ NOTE 
1 CONT 
1 CONT 1880 Census Place: Elizabeth, Lawrence, Ohio: Plas WILLIS, Self, M, W, W, 44, Ohio, Occ: Laborer, Fa: VA, Mo: VA, 
```
